### PR TITLE
Fix settings option key mismatch (bug 1.1)

### DIFF
--- a/includes/class-cron-jobs.php
+++ b/includes/class-cron-jobs.php
@@ -66,8 +66,10 @@ class Cron_Jobs {
 		$args['batch_size']  = $this->get_batch_size();
 		$interval_in_seconds = $this->get_interval_in_seconds();
 
-		$this->settings['batch_size'] = ( isset( $this->settings['batch_size'] ) ) ? $this->settings['batch_size'] : 0;
-		$this->settings['interval']   = ( isset( $this->settings['interval'] ) ) ? $this->settings['interval'] : 0;
+		$scheduler_state = get_option( 'hog_scheduler_state', array() );
+
+		$this->settings['batch_size'] = ( isset( $scheduler_state['batch_size'] ) ) ? $scheduler_state['batch_size'] : 0;
+		$this->settings['interval']   = ( isset( $scheduler_state['interval'] ) ) ? $scheduler_state['interval'] : 0;
 
 		//todo if current action is okay, leave it.
 		if ( $this->settings['batch_size'] == $args['batch_size'] && $this->settings['interval'] = $interval_in_seconds ) {
@@ -80,10 +82,10 @@ class Cron_Jobs {
 
 		$result = as_schedule_recurring_action( time(), $interval_in_seconds, $this->action_hook, $args, 'happy-order-generator', true );
 
-		$this->settings['batch_size'] = $args['batch_size'];
-		$this->settings['interval']   = $interval_in_seconds;
-
-		update_option( 'wc_order_generator_settings', $this->settings );
+		update_option( 'hog_scheduler_state', array(
+			'batch_size' => $args['batch_size'],
+			'interval'   => $interval_in_seconds,
+		) );
 
 	}
 

--- a/includes/class-generator.php
+++ b/includes/class-generator.php
@@ -60,7 +60,7 @@ class Generator {
 
 	public function __construct() {
 
-		$this->settings = get_option( 'wc_order_generator_settings', array() );
+		$this->settings = Order_Generator::get_settings();
 
 
 	}

--- a/includes/class-installer.php
+++ b/includes/class-installer.php
@@ -47,5 +47,12 @@ namespace Happy_Order_Generator;
 	 }
 
      public static function activate_plugin():void{
+
+         /**
+          * Remove the orphaned option written by older versions that saved
+          * scheduler state to the wrong key. Settings now live in
+          * happy_order_generator_settings and scheduler state in hog_scheduler_state.
+          */
+         delete_option( 'wc_order_generator_settings' );
     }
 }


### PR DESCRIPTION
## Bug 1.1 — Settings option key mismatch

Fixes the high-severity config bug where the Generator read user settings from the wrong option key, and the scheduler wrote its state into a key nobody read back.

### Changes

- **`includes/class-generator.php`** — `Generator::__construct()` read `wc_order_generator_settings` directly, but the settings page saves to `happy_order_generator_settings`. The status-percentage settings the Generator relies on were therefore stale or empty. Now routed through `Order_Generator::get_settings()`.
- **`includes/class-cron-jobs.php`** — `setup_action_scheduler()` wrote computed `batch_size`/`interval` back into the orphaned `wc_order_generator_settings` option (which it never read from). Scheduler state now lives in its own `hog_scheduler_state` option, used for both the read (the "is the existing schedule still correct?" comparison) and the write — so the comparison actually runs against persisted values.
- **`includes/class-installer.php`** — `activate_plugin()` now deletes the orphaned `wc_order_generator_settings` option. (No version-based upgrade routine exists; activation is the only install-time hook available, so cleanup happens on reactivation.)

### Scope notes

- The `=`-vs-`==` typo on `class-cron-jobs.php:73` is **bug 1.5** and is intentionally left untouched here so it can be fixed on its own `fix/scheduler-interval-check` branch (one PR per bug).
- `php -l` passes on all three changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)