### PR TITLE
Fix log_customer_in() reading $_POST on JSON request (bug 1.3)

### DIFF
--- a/woocommerce-order-generator.php
+++ b/woocommerce-order-generator.php
@@ -130,7 +130,17 @@ class Order_Generator {
 	 */
 	public function log_customer_in( $customer, $request ): void {
 
-		$user = get_user_by( 'email', sanitize_email( $_POST['billing_address']['email'] ) );
+		/**
+		 * Store API checkout requests carry a JSON body, so $_POST is empty.
+		 * Read the email from the request object provided by the hook.
+		 */
+		$billing_address = $request['billing_address'] ?? array();
+
+		if ( empty( $billing_address['email'] ) ) {
+			return;
+		}
+
+		$user = get_user_by( 'email', sanitize_email( $billing_address['email'] ) );
 
 		if ( $user ) {
 			wc_set_customer_auth_cookie( $user->ID );


### PR DESCRIPTION
## Summary
Fixes Phase 1 bug **1.3** from the [release roadmap](documentation/roadmap.md).

`Order_Generator::log_customer_in()` read `$_POST['billing_address']['email']`, but Store API checkout requests carry a **JSON body**, so `$_POST` is empty — the customer was never logged in (and the code would notice-fail on the missing index).

## Change
- Read the email from the `$request` object provided by the `woocommerce_store_api_checkout_update_customer_from_request` hook.
- Guard against a missing/empty billing email (return early instead of erroring).

## Test plan
- Trigger a Store API checkout for an existing customer email → user is now logged in (auth cookie set).
- Checkout with no billing email in the request → no notice/fatal, returns cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)