### PR TITLE
Fix Logger fatal on WP_Error and unguarded debug setting (bug 1.4)

### DIFF
--- a/includes/class-logger.php
+++ b/includes/class-logger.php
@@ -28,7 +28,7 @@ class Logger {
 
 		$settings = Order_Generator::get_settings();
 
-		if( $settings['enable_debug'] !== 'yes' ){
+		if( ( $settings['enable_debug'] ?? 'no' ) !== 'yes' ){
 			return;
 		}
 
@@ -40,7 +40,7 @@ class Logger {
 		if( is_wp_error( $message )){
 
 			self::$logger->debug( $message->get_code(), array( 'source' => self::LOG_NAME ) );
-			self::$logger->error( $message->get_all_error_messages(), array( 'source' => self::LOG_NAME ) );
+			self::$logger->error( implode( ', ', $message->get_error_messages() ), array( 'source' => self::LOG_NAME ) );
 			return;
 		}
 


### PR DESCRIPTION
## Summary
Fixes Phase 1 bug **1.4** from the [release roadmap](documentation/roadmap.md).

- `Logger::log()` called `$message->get_all_error_messages()` — a method that does **not** exist on `WP_Error` (it's `get_error_messages()`). Logging an error object fataled exactly when something had already gone wrong. Now uses `get_error_messages()` and `implode`s the array into the string `WC_Logger` expects.
- `enable_debug` was read without an `isset()` guard, emitting undefined-index warnings on fresh installs where settings were never saved. Now defaults to `'no'`.

## Test plan
- Call `Logger::log( new WP_Error( 'x', 'boom' ) )` with debug enabled → logs cleanly, no fatal.
- Fresh install (no saved settings) → no undefined-index warning, logging is gated off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)