### PR TITLE
Fix assignment instead of comparison in scheduler check (bug 1.5)

### DIFF
--- a/includes/class-cron-jobs.php
+++ b/includes/class-cron-jobs.php
@@ -70,7 +70,7 @@ class Cron_Jobs {
 		$this->settings['interval']   = ( isset( $this->settings['interval'] ) ) ? $this->settings['interval'] : 0;
 
 		//todo if current action is okay, leave it.
-		if ( $this->settings['batch_size'] == $args['batch_size'] && $this->settings['interval'] = $interval_in_seconds ) {
+		if ( $this->settings['batch_size'] == $args['batch_size'] && $this->settings['interval'] == $interval_in_seconds ) {
 			if ( as_has_scheduled_action( $this->action_hook ) ) {
 				return;
 			}


### PR DESCRIPTION
## Summary
Fixes Phase 1 bug **1.5** from the [release roadmap](documentation/roadmap.md).

`Cron_Jobs::setup_action_scheduler()` used `$this->settings['interval'] = $interval_in_seconds` (assignment) inside the `if` condition instead of `==`. The condition always evaluated truthy and overwrote the stored interval, so the "leave the existing scheduled action alone" short-circuit misbehaved and the recurring action was rescheduled more often than intended.

## Test plan
- With an existing scheduled action whose batch size and interval already match, re-running setup leaves it untouched (no reschedule).
- Changing orders-per-hour still reschedules as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)