### PR TITLE
Detect variable-subscription variations in cart (bug 1.7)

### DIFF
--- a/includes/class-generator.php
+++ b/includes/class-generator.php
@@ -220,7 +220,12 @@ class Generator {
 		foreach ( $cart_items as $cart_item ) {
 
 			$product = wc_get_product( $cart_item['id'] );
-			if ( $product->is_type( 'subscription' ) || $product->is_type( 'variable-subscription' ) ) {
+
+			if ( ! $product ) {
+				continue;
+			}
+
+			if ( $product->is_type( 'subscription' ) || $product->is_type( 'variable-subscription' ) || $product->is_type( 'subscription_variation' ) ) {
 				return true;
 			}
 		}


### PR DESCRIPTION
## Summary
Fixes Phase 1 bug **1.7** from the [release roadmap](documentation/roadmap.md).

`Generator::check_cart_for_subscription()` checked product types `subscription` and `variable-subscription`, but cart items for variable subscriptions carry the **variation** ID, whose type is `subscription_variation`. Such carts were missed and could be routed to BACS, creating manual renewals.

## Change
- Include `subscription_variation` in the type check.
- Guard against `wc_get_product()` returning `false` (skip the item instead of calling `is_type()` on a non-object).

## Test plan
- Cart containing a variable-subscription variation → detected as a subscription, routed to Stripe (not BACS).
- Cart with an invalid/deleted product ID → no fatal, item skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)