### PR TITLE
Mark generated users with identifying meta (#1)

### DIFF
--- a/includes/class-customer.php
+++ b/includes/class-customer.php
@@ -127,6 +127,10 @@ class Customer {
 			'shipping_email'       => $faker->email(),
 			'shipping_phone'       => $faker->phoneNumber(),
 			'_customer_ip_address' => $faker->ipv4(),
+			// Identifies users created by the plugin, mirroring the
+			// _happy_order_generator_order meta on generated orders so
+			// generated customers can be found and purged.
+			'_happy_order_generator_user' => 1,
 			'billing_company'      => '',
 			'billing_address_2'    => '',
 			'shipping_company'     => '',


### PR DESCRIPTION
## Summary
Implements roadmap **Phase 1.5.1** / closes #1.

Generated orders already carry `_happy_order_generator_order = 1`, which lets a site identify and purge generated orders. Customers created by the plugin had no equivalent marker, so generated users couldn't be cleanly found or removed.

## Change
- `Customer::create_user()` now writes `_happy_order_generator_user = 1` user meta on every customer the plugin creates, added to the existing meta array so it goes through the same `update_user_meta()` loop.
- Mirrors the `_happy_order_generator_order` order-meta convention exactly so the two are symmetrical.

## Scope note
The `uninstall.php` cleanup that *consumes* this marker (deleting generated users behind an opt-in constant) is intentionally **out of scope** — it's tracked in Phase 3 housekeeping. This PR just lays down the identifying meta so that work has something to query.

## Test plan
- Generate an order in new-customer mode → the created user has `_happy_order_generator_user` meta set to `1`.
- `get_users( array( 'meta_key' => '_happy_order_generator_user', 'meta_value' => 1 ) )` returns generated customers and excludes real ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)